### PR TITLE
Fix Chrome's problem when a password is mis-encrypted

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Chrome stores all the sign-on secrets into the internal database file called 'We
 
 The logins table mainly contains the information about sign-on secrets such as website URL, username, password fields etc. All this information is stored in the clear text except passwords which are in encrypted format.
 
-Unfortunately, sometimes a password gets garbled and cannot be decrypted. Chrome behaves rather erratically in this case, as it still fils in passwords and saves new ones, but cannot display or sync saved passwords. You can use this little utility to see all passwords except the garbled ones (which are presumed lost).
+Unfortunately, sometimes a password gets garbled and cannot be decrypted. Chrome behaves rather erratically in this case, as it still fills in passwords and saves new ones, but cannot display or sync saved passwords. You can use this little utility to see all passwords except the garbled ones (which are presumed lost).
 
-You can also use it to create a version of the password database without the garbled entries. However, you must copy the result into the Chrome directory yourself. We strongly recommend that you BACK UP the password database (named "Login Data") before overwriting it with the new version, as the functionality is NOT VERY WELL TESTED. And then, if your passwords are lost, just restore the old file.
+You can also use it to create a version of the password database without the garbled entries. However, you must copy the result into the Chrome directory yourself. We strongly recommend that you BACK UP the password database (named `Login Data`) before overwriting it with the new version, as the functionality is NOT VERY WELL TESTED. And then, if your passwords are lost, just restore the old file.
 
 #### Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,18 @@ Like other browsers Chrome also has built-in login password manager functionalit
 
 Chrome stores all the sign-on secrets into the internal database file called 'Web data' in the current user profile folder. Newer version has moved the login passwords related database into new file named 'Login Data'.This database file is in SQLite format and contains number of tables storing different kind of data such as auto complete, search keyword, ie7logins etc in addition to login secrets.
 
-The logins table mainly contains the information about sign-on secrets such as website URL, username, password fields etc. All this information is stored in the clear text except passwords which are in encrypted format. 
+The logins table mainly contains the information about sign-on secrets such as website URL, username, password fields etc. All this information is stored in the clear text except passwords which are in encrypted format.
+
+Unfortunately, sometimes a password gets garbled and cannot be decrypted. Chrome behaves rather erratically in this case, as it still fils in passwords and saves new ones, but cannot display or sync saved passwords. You can use this little utility to see all passwords except the garbled ones (which are presumed lost).
+
+You can also use it to create a version of the password database without the garbled entries. However, you must copy the result into the Chrome directory yourself. We strongly recommend that you BACK UP the password database (named "Login Data") before overwriting it with the new version, as the functionality is NOT VERY WELL TESTED. And then, if your passwords are lost, just restore the old file.
+
+#### Prerequisites
+
+Install the following packages using pip:
+
+* secretstorage
+* pycryptodome
 
 #### Windows Implementation
 Google Chrome encrypt the password with the help of CryptProtectData function, built into Windows. Now while this can be a very secure function using a triple-DES algorithm and creating user-specific keys to encrypt the data, it can still be decrypted as long as you are logged into the same account as the user who encrypted it.The CryptProtectData function has a twin, who does the opposite to it; CryptUnprotectData, which... well you guessed it, decrypts the data. And obviously this is going to be very useful in trying to decrypt the stored passwords.
@@ -28,6 +39,8 @@ Encryption Scheme: AES-128 CBC with a constant salt and constant iterations. The
 
 
 ## Python Implementation (Working)
+
+Stop Chrome before running this utility.
 
 #### Usage
 ```python
@@ -52,11 +65,18 @@ Encryption Scheme: AES-128 CBC with a constant salt and constant iterations. The
 }
 ```
 
+To generate a new `Login Data` in the current directory:
+```
+>>> chrome_pwd.rewrite_passwords()
+Failed and excluded: INSERT INTO "logins" VALUES('https://some.website.com/password/change/blah','https://some.website.com/password/change/blah','','some@user.com','password',X'FF00FF00FF00','','https://some.website.com/',1334343408358214120,0,0,0,0,X'9801000006000000000000005800000068747470733A2F2F617574682E6265656C647374656D6D656E9485349758394875394579348758616E67652F75663538575F4443433643663833776D713173796C46773874623979574C73335038676A5F366B3546586B3300000068747470733A2F2F617574682E6265656C647374656D6D656E2E6E6C2F70617373776F72642F6368616E67652F6368616E67650002000000080000000000000008000000700061007300730077006F0072006400000000000800000070617373776F726400000000FFFFFF7F000000000000000000000000010000000100000001000000020000000000000000000000000000000000000001000000000000000000000008000000000000000F000000700061007300730077006F007200640043006F006E006600690072006D000000000000000800000070617373776F726400000000FFFFFF7F00000000000000000000000001000000010000000100000002000000000000000000000000000000000000000500000000000000000000000100000000000000040000006E756C6C',0,'','','',0,0,X'00000000',4,1876808358214086,X'00000000');
+New Login Data ready, use at your own risk
+```
+
+Then back up Chrome's `Login Data` file and overwrite it with the new one that is in your current directory.
+
 ## Contribute
 Feel free to contribute. Please Follow PEP8 Guidelines.
 
 TO DO:
 * Cookie support
 * Updating database password directly
-
-


### PR DESCRIPTION
Hello,

Chrome, at least on Linux, has a frequent problem. A password gets mis-encrypted, this happens. But instead of just losing that one password, Google Chrome fails to display passwords in its settings and fails to push them into the Google account when syncing. As a result, the passwords are still there, but as soon as one loses the repo for some reason (like a reinstall or even enabling a KDE/Gnome wallet) - poof, they are gone!

I was at a loss for a solution, but I found this utility which was nearly ready for it. "Nearly" beacuse it crashed with an exception upon encountering a mis-encrypted password.

My changes:

- By default, the exception is now handled, outputting the exception text instead of the password. So one can now get a password dump and all the valid passwords are still there.
- Added rewrite_passwords(), which creates a new copy of "Login Data" in the current directory - with the faulty lines excised. To avoid analysing the entire database, I instead do an SQL dump and execute, while deciphering passwords on the fly from the SQL dump; this is bad,  but trying to re-create every table without a dump would be worse.
- Updated the readme for my changes, for the modules that I had to install using pip to make the utility work, and for the need to stop Chrome before playing with its database

Note that, when using rewrite_passwords, the user still has to copy "Login Data" into the Chrome config directory manually. I did this to ensure that one knows what one is doing. The procedure was only tested once, and so a backup is essential if it fails. (If the routine finds an existing "Login Data" file in the current directory, it stops to avoid overwriting it).

For avoidance of doubt:

- My contribution is under the same license as the original, GPL3, as expected
- While the PR comes from my work github account, it is a personal contribution; Red Hat has an explicit policy allowing such contributions

I would appreciate a merge because I'd like to post links to this workaround on forums where people complain about this issue.
