### PR TITLE
Update requirements_mac.txt

### DIFF
--- a/requirements_mac.txt
+++ b/requirements_mac.txt
@@ -1,2 +1,3 @@
 SecretStorage==3.3.0
 pycrypto==2.6.1
+cryptography==3.3


### PR DESCRIPTION
Otherwise will get errors while importing looking like `from cryptography.utils import int_from_bytes ImportError: cannot import name 'int_from_byte`